### PR TITLE
Don't send travis notifications to the FOS mailing-list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,3 @@ before_script:
     - composer install
 
 script: phpunit -c  app --coverage-text
-
-notifications:
-    email:
-        - friendsofsymfony-dev@googlegroups.com


### PR DESCRIPTION
The FOS team is not concerned with build notifications for your project
